### PR TITLE
Add image attachment support to agent

### DIFF
--- a/jerma/cogs/agent.py
+++ b/jerma/cogs/agent.py
@@ -111,7 +111,8 @@ class Agent(commands.Cog):
         async def ensure_channel():
             nonlocal channel
             if channel is None:
-                channel = await message.create_thread(name=prompt[:80])
+                channel = await message.create_thread(
+                    name=(prompt or 'image attachment')[:80])
                 typing.move_to(channel)
             return channel
 

--- a/jerma/cogs/agent.py
+++ b/jerma/cogs/agent.py
@@ -54,7 +54,9 @@ class Agent(commands.Cog):
         else:
             return
         prompt = raw.strip()
-        if not prompt:
+        images = [a for a in message.attachments
+                  if a.content_type and a.content_type.startswith('image/')]
+        if not prompt and not images:
             return
 
         if not await self.bot.is_owner(message.author):
@@ -64,7 +66,7 @@ class Agent(commands.Cog):
         if ctx.valid:
             return
 
-        await self._handle_prompt(message, prompt)
+        await self._handle_prompt(message, prompt, images)
 
     def _strip_mention(self, content: str) -> str | None:
         """The rest of a message that leads with a ping of the bot, else None."""
@@ -81,7 +83,8 @@ class Agent(commands.Cog):
         return (isinstance(channel, discord.Thread)
                 and channel.owner_id == self.bot.user.id)
 
-    async def _handle_prompt(self, message: discord.Message, prompt: str):
+    async def _handle_prompt(self, message: discord.Message, prompt: str,
+                              images: list[discord.Attachment] = ()):
         """Run one turn: a typing indicator shows the agent working, and a
         thread is created right before the first reply so the whole
         conversation — including any follow-ups — lives inside it."""
@@ -128,8 +131,12 @@ class Agent(commands.Cog):
 
         try:
             async with typing:
+                image_data = []
+                for a in images:
+                    image_data.append((a.filename, await a.read()))
                 report = await self.service.run(key, prompt,
-                                                on_progress=send_in_thread)
+                                                on_progress=send_in_thread,
+                                                images=image_data)
         except WorkspaceError as error:
             await set_status(f'Workspace error:\n{error}')
             return

--- a/jerma/cogs/utils/agent_runner.py
+++ b/jerma/cogs/utils/agent_runner.py
@@ -64,7 +64,8 @@ def _split_reply(prompt: str, reply: str) -> tuple[str, str]:
     title = first.strip('#*` ')  # tolerate heading/bold markup
     if title:
         return title, rest.strip()
-    return prompt.strip().splitlines()[0], reply.strip()
+    lines = (prompt.strip() or reply.strip()).splitlines()
+    return (lines[0] if lines else 'untitled'), reply.strip()
 
 
 def _deny(reason: str) -> HookJSONOutput:
@@ -159,7 +160,8 @@ def _build_options(workspace_root: Path,
 async def run_agent(prompt: str, workspace_root: Path,
                     repos: dict[str, AgentRepo],
                     on_progress: OnProgress,
-                    resume: str | None = None) -> AgentRunResult:
+                    resume: str | None = None,
+                    image_paths: list[Path] = ()) -> AgentRunResult:
     """Run one agent turn; interim narration streams, the answer returns.
 
     Pass a previous result's session_id as resume to continue that
@@ -199,6 +201,11 @@ async def run_agent(prompt: str, workspace_root: Path,
     async def deliver():
         while (text := await outbox.get()) is not None:
             await on_progress(text)
+
+    if image_paths:
+        paths_str = '\n'.join(f'- {p}' for p in image_paths)
+        prompt = (f'{prompt}\n\nImage attachment(s) saved in the workspace:\n'
+                  f'{paths_str}\nUse the Read tool to view them.')
 
     options = _build_options(workspace_root, repos, resume)
     async with ClaudeSDKClient(options=options) as client:

--- a/jerma/cogs/utils/agent_service.py
+++ b/jerma/cogs/utils/agent_service.py
@@ -104,7 +104,8 @@ class AgentTaskService:
                 task.cancel()
 
     async def run(self, key: int, prompt: str,
-                  on_progress: OnProgress) -> TaskReport:
+                  on_progress: OnProgress,
+                  images: list[tuple[str, bytes]] = ()) -> TaskReport:
         """Run one turn of the keyed conversation, creating it if new.
 
         Turns of the same conversation queue on its lock; different
@@ -113,12 +114,14 @@ class AgentTaskService:
         conversation = await self._get_or_create(key, prompt)
         async with conversation.lock:
             conversation.last_active = datetime.now()
+            image_paths = self._save_images(conversation.checkout.root, images)
             result = await run_agent(
                 prompt=prompt,
                 workspace_root=conversation.checkout.root,
                 repos=self.workspace.repos,
                 on_progress=on_progress,
                 resume=conversation.session_id,
+                image_paths=image_paths,
             )
             if result.session_id is not None:
                 conversation.session_id = result.session_id
@@ -132,6 +135,19 @@ class AgentTaskService:
             return TaskReport(answer=result.final_text,
                               pull_requests=pull_requests,
                               timed_out=result.timed_out)
+
+    def _save_images(self, root: Path,
+                     images: list[tuple[str, bytes]]) -> list[Path]:
+        if not images:
+            return []
+        attachments_dir = root / '_attachments'
+        attachments_dir.mkdir(exist_ok=True)
+        paths = []
+        for filename, data in images:
+            path = attachments_dir / Path(filename).name
+            path.write_bytes(data)
+            paths.append(path)
+        return paths
 
     async def _get_or_create(self, key: int, prompt: str) -> Conversation:
         conversation = self.conversations.get(key)


### PR DESCRIPTION
Add image attachment support to the agent feature

Discord image attachments are now downloaded and saved into the conversation workspace so the agent can view them with the Read tool.

**What changed across three files:**

- **`agent.py`**: `on_message` filters image attachments (MIME type `image/*`) and passes them through. The empty-prompt guard is relaxed to allow image-only messages. `_handle_prompt` downloads the attachment bytes inside the existing `try` block before handing off to the service.

- **`agent_service.py`**: `run()` gains an `images: list[tuple[str, bytes]]` parameter. A new `_save_images()` method writes them to `<checkout_root>/_attachments/` (outside all repo subdirectories, so they're never committed) and returns their paths. `Path(filename).name` strips any path components before writing, preventing traversal attacks.

- **`agent_runner.py`**: `run_agent()` gains `image_paths`. When present, absolute paths are appended to the prompt telling the agent to use the Read tool to view them. `_split_reply` is also fixed for the image-only (empty text prompt) edge case — it now falls back to the reply text before giving up with `'untitled'`.

---
Opened by the JermaBot coding agent at the owner's request via Discord.