### PR TITLE
Add read-only whid-member agent mode with intent classifier

### DIFF
--- a/jerma/cogs/agent.py
+++ b/jerma/cogs/agent.py
@@ -1,13 +1,14 @@
-"""Owner-only coding agent: ping JermaBot with a request, get answers or PRs.
+"""Coding agent for JermaBot: owner (full) and whid-member (read-only) modes.
 
-When the owner pings the bot with something that isn't a command, the
-message starts a coding-agent conversation. Replies live in a thread
-created just before the first one, and further owner messages in that
-thread continue the conversation — no ping needed. Conversations run
-concurrently, each keeping one branch and at most one pull request per
-repo, updated turn by turn. This cog handles only the Discord side —
-detection, threads, message chunking, and reporting; conversations execute
-behind AgentTaskService.
+Owner mode — ping or reply in a bot-owned thread — starts a coding-agent
+conversation that can read, edit, and open pull requests. Conversations are
+persistent across bot restarts.
+
+Whid-member mode — ping only, in the whid Discord server — activates a
+read-only agent that can answer questions about the code but cannot make
+any edits or create pull requests. An intent classifier gates entry: a
+message that looks like a misspelled command is silently ignored. Thread
+continuations skip re-classification.
 """
 import asyncio
 import math
@@ -18,8 +19,9 @@ import discord
 from discord.ext import commands
 
 from jermabot import JermaBot
-from .utils.agent_config import AGENT_TIMEOUT_SECONDS
-from .utils.agent_service import AgentTaskService, WorkspaceError
+from .utils.agent_config import AGENT_TIMEOUT_SECONDS, WHID_GUILD_ID
+from .utils.agent_runner import classify_intent
+from .utils.agent_service import AgentTaskService, ReadonlyAgentTaskService, WorkspaceError
 from .utils.split_message import MESSAGE_LIMIT, split_message
 
 
@@ -47,44 +49,67 @@ class Agent(commands.Cog):
     def __init__(self, bot: JermaBot):
         self.bot = bot
         self.service = AgentTaskService()
+        self.readonly_service = ReadonlyAgentTaskService()
 
     async def cog_load(self):
         self.service.start()
+        self.readonly_service.start()
 
     async def cog_unload(self):
         self.service.close()
+        self.readonly_service.close()
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         if message.author.bot or self.bot.user is None:
             return
 
-        # A conversation in a thread the bot created hears every owner
-        # message; anywhere else — channels, DMs, other people's threads —
-        # it takes a ping to start or continue one.
         stripped = self._strip_mention(message.content)
-        if stripped is not None:
-            raw = stripped
-        elif (self.service.has_conversation(message.channel.id)
-                and self._is_own_thread(message.channel)):
-            raw = message.content
-        else:
-            return
-        prompt = raw.strip()
-        images = [a for a in message.attachments
-                  if a.content_type and a.content_type.startswith('image/')]
-        inline_urls = _collect_embed_image_urls(message)
-        if not prompt and not images and not inline_urls:
-            return
 
-        if not await self.bot.is_owner(message.author):
-            return
+        if await self.bot.is_owner(message.author):
+            # Owner path: thread continuations need no ping.
+            if stripped is not None:
+                raw = stripped
+            elif (self.service.has_conversation(message.channel.id)
+                  and self._is_own_thread(message.channel)):
+                raw = message.content
+            else:
+                return
+            prompt = raw.strip()
+            images = [a for a in message.attachments
+                      if a.content_type and a.content_type.startswith('image/')]
+            inline_urls = _collect_embed_image_urls(message)
+            if not prompt and not images and not inline_urls:
+                return
+            ctx = await self.bot.get_context(message)
+            if ctx.valid:
+                return
+            await self._handle_prompt(message, prompt, images, inline_urls)
 
-        ctx = await self.bot.get_context(message)
-        if ctx.valid:
-            return
-
-        await self._handle_prompt(message, prompt, images, inline_urls)
+        elif self._is_whid_member(message):
+            # Whid-member path: read-only, intent-gated.
+            # Thread continuations in an established readonly conversation skip
+            # classification (the user is already in a deliberate session).
+            is_ping = stripped is not None
+            if is_ping:
+                raw = stripped
+            elif (self.readonly_service.has_conversation(message.channel.id)
+                  and self._is_own_thread(message.channel)):
+                raw = message.content
+            else:
+                return
+            prompt = raw.strip()
+            images = [a for a in message.attachments
+                      if a.content_type and a.content_type.startswith('image/')]
+            inline_urls = _collect_embed_image_urls(message)
+            if not prompt and not images and not inline_urls:
+                return
+            ctx = await self.bot.get_context(message)
+            if ctx.valid:
+                return
+            if is_ping and not await classify_intent(prompt):
+                return
+            await self._handle_readonly_prompt(message, prompt, images, inline_urls)
 
     def _strip_mention(self, content: str) -> str | None:
         """The rest of a message that leads with a ping of the bot, else None."""
@@ -95,6 +120,10 @@ class Agent(commands.Cog):
                 return content.removeprefix(mention)
 
         return None
+
+    def _is_whid_member(self, message: discord.Message) -> bool:
+        return (message.guild is not None
+                and message.guild.id == WHID_GUILD_ID)
 
     def _is_own_thread(self, channel) -> bool:
         assert self.bot.user is not None
@@ -196,6 +225,87 @@ class Agent(commands.Cog):
                 await target.send(f'{verb} for '
                                   f'**{pull_request.repo_name}**: '
                                   f'{pull_request.url}')
+
+    async def _handle_readonly_prompt(self, message: discord.Message,
+                                       prompt: str,
+                                       images: list[discord.Attachment] = (),
+                                       inline_urls: list[str] = ()):
+        """One turn of a whid-member readonly conversation.
+
+        Identical Discord mechanics to _handle_prompt (typing, thread, chunked
+        replies) but calls the readonly service — no edits, no PRs.
+        """
+        contained = isinstance(message.channel,
+                               (discord.Thread, discord.DMChannel))
+        if not contained and not self._can_create_thread(message):
+            await message.reply("I can't make a thread here :(")
+            return
+
+        typing = _TypingIndicator(message.channel)
+        key = message.channel.id if contained else message.id
+        channel = message.channel if contained else None
+        status: discord.Message | None = None
+
+        async def ensure_channel():
+            nonlocal channel
+            if channel is None:
+                channel = await message.create_thread(
+                    name=(prompt or 'image attachment')[:80])
+                typing.move_to(channel)
+            return channel
+
+        async def set_status(text: str):
+            nonlocal status
+            text = text[:MESSAGE_LIMIT]
+            if status is not None:
+                await status.edit(content=text)
+            else:
+                send = channel.send if channel else message.reply
+                status = await send(text)
+
+        async def send_in_thread(text: str):
+            await self._send_message(await ensure_channel(), text)
+
+        try:
+            async with typing:
+                image_data = []
+                for a in images:
+                    image_data.append((a.filename, await a.read()))
+                if inline_urls:
+                    async with aiohttp.ClientSession() as session:
+                        for url in inline_urls:
+                            try:
+                                async with session.get(url) as resp:
+                                    ct = resp.headers.get('Content-Type', '')
+                                    if resp.status == 200 and ct.startswith('image/'):
+                                        filename = (url.rstrip('/').split('/')[-1]
+                                                    .split('?')[0] or 'image')
+                                        image_data.append((filename,
+                                                           await resp.read()))
+                            except Exception:
+                                pass
+                report = await self.readonly_service.run(
+                    key, prompt,
+                    on_progress=send_in_thread,
+                    images=image_data,
+                )
+        except WorkspaceError as error:
+            await set_status(f'Workspace error:\n{error}')
+            return
+        except Exception:
+            trace = traceback.format_exc()[-1500:]
+            await set_status(f'Error:\n```py\n{trace}\n```')
+            return
+
+        answer = report.answer.strip()
+        if answer:
+            await send_in_thread(answer)
+        elif not report.timed_out:
+            await set_status('(The agent finished without saying anything.)')
+
+        if report.timed_out:
+            await set_status(
+                f'(Hit the {AGENT_TIMEOUT_SECONDS // 60} minute limit.)')
 
     def _can_create_thread(self, message: discord.Message) -> bool:
         """Whether a response thread could be made, should the task need one."""

--- a/jerma/cogs/utils/agent_config.py
+++ b/jerma/cogs/utils/agent_config.py
@@ -1,8 +1,9 @@
-"""Configuration for the owner-only coding agent feature."""
+"""Configuration for the coding agent features."""
 import os
 from dataclasses import dataclass
 from pathlib import Path
 
+WHID_GUILD_ID = 173840048343482368
 
 AGENT_TIMEOUT_SECONDS = 900
 AGENT_MAX_TURNS = 50
@@ -52,6 +53,12 @@ def get_conversations_root() -> Path:
     """Directory holding per-conversation checkouts and their state file."""
     return _env_dir('JERMABOT_AGENT_CONVERSATIONS_DIR',
                     '~/jermabot-agent/conversations')
+
+
+def get_readonly_conversations_root() -> Path:
+    """Directory for readonly-mode SDK session working directories."""
+    return _env_dir('JERMABOT_AGENT_READONLY_DIR',
+                    '~/jermabot-agent/readonly-conversations')
 
 
 def get_github_token() -> str | None:

--- a/jerma/cogs/utils/agent_runner.py
+++ b/jerma/cogs/utils/agent_runner.py
@@ -37,6 +37,9 @@ from .agent_config import (
 os.environ.pop('ANTHROPIC_API_KEY', None)
 
 AGENT_TOOLS = ['Read', 'Edit', 'Write', 'Glob', 'Grep']
+READONLY_AGENT_TOOLS = ['Read', 'Glob', 'Grep']
+
+_INTENT_CLASSIFIER_TIMEOUT = 30
 # notebook_path isn't used by any allowed tool today; it's defense in depth
 # in case NotebookEdit ever joins AGENT_TOOLS.
 _PATH_KEYS = ('file_path', 'path', 'notebook_path')
@@ -87,12 +90,12 @@ def _allow() -> HookJSONOutput:
     }
 
 
-def _make_path_guard(root: Path):
+def _make_path_guard(root: Path, allowed_tools: list[str] = AGENT_TOOLS):
     """PreToolUse hook: only the allowed tools, only inside the workspace."""
     async def guard(input_data, tool_use_id, context) -> HookJSONOutput:
         tool_name = input_data.get('tool_name', '')
         tool_input = input_data.get('tool_input') or {}
-        if tool_name not in AGENT_TOOLS:
+        if tool_name not in allowed_tools:
             return _deny(f'The {tool_name} tool is not permitted.')
         for key in _PATH_KEYS:
             raw = tool_input.get(key)
@@ -155,6 +158,156 @@ def _build_options(workspace_root: Path,
             'PreToolUse': [HookMatcher(hooks=[_make_path_guard(workspace_root)])],
         },
     )
+
+
+async def classify_intent(message_text: str) -> bool:
+    """Return True if message_text is a genuine request for a bot response.
+
+    Runs a single-turn Claude session with no tools. On any error, returns
+    False so accidental invocations are always silent.
+    """
+    prompt = (
+        'Classify the following Discord message. '
+        'The message was sent to JermaBot (a Discord bot) by a server member. '
+        'Is this a genuine, intentional request for a natural-language response '
+        '(e.g. asking a question, starting a conversation, making a request)? '
+        'A misspelled or garbled command (starting with !, /, ., or a similar '
+        'symbol prefix) is NOT a genuine request. '
+        'Reply with only YES or NO.\n\n'
+        f'Message: {message_text.strip() or "(empty)"}'
+    )
+
+    result_holder = {'text': ''}
+    options = ClaudeAgentOptions(
+        cwd=str(Path.home()),
+        resume=None,
+        tools=[],
+        disallowed_tools=['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep',
+                          'Task', 'WebFetch', 'WebSearch', 'NotebookEdit'],
+        permission_mode='acceptEdits',
+        setting_sources=[],
+        max_turns=1,
+        system_prompt={
+            'type': 'preset',
+            'preset': 'claude_code',
+            'append': 'When asked to classify a message, reply with only YES or NO.',
+        },
+    )
+
+    async def _consume(client: ClaudeSDKClient):
+        async for msg in client.receive_response():
+            if isinstance(msg, AssistantMessage):
+                for block in msg.content:
+                    if isinstance(block, TextBlock) and block.text:
+                        result_holder['text'] += block.text
+            elif isinstance(msg, ResultMessage) and msg.result:
+                result_holder['text'] = msg.result
+
+    try:
+        async with ClaudeSDKClient(options=options) as client:
+            await client.query(prompt)
+            await asyncio.wait_for(_consume(client),
+                                   timeout=_INTENT_CLASSIFIER_TIMEOUT)
+    except Exception:
+        return False
+
+    return 'yes' in result_holder['text'].lower()
+
+
+def _build_readonly_instructions(repos: dict[str, AgentRepo]) -> str:
+    repo_lines = '\n'.join(
+        f'- {name}/ — github.com/{repo.slug}, base branch {repo.base_branch}'
+        for name, repo in repos.items()
+    )
+    return (
+        'You are JermaBot, chatting with members of a Discord server. '
+        'Your working directory contains read-only checkouts of:\n'
+        f'{repo_lines}\n\n'
+        '- You may read files to answer questions but cannot make edits or '
+        'open pull requests.\n'
+        '- Answer questions, explain code, and help users understand the repos.\n'
+        '- Off-topic questions are fine; just answer them.\n'
+        '- Keep responses friendly and concise.'
+    )
+
+
+def _build_readonly_options(workspace_root: Path,
+                             repos: dict[str, AgentRepo],
+                             resume: str | None) -> ClaudeAgentOptions:
+    return ClaudeAgentOptions(
+        cwd=str(workspace_root),
+        resume=resume,
+        tools=list(READONLY_AGENT_TOOLS),
+        disallowed_tools=['Bash', 'Task', 'WebFetch', 'WebSearch',
+                          'Edit', 'Write', 'NotebookEdit'],
+        permission_mode='acceptEdits',
+        setting_sources=[],
+        max_turns=AGENT_MAX_TURNS,
+        system_prompt={
+            'type': 'preset',
+            'preset': 'claude_code',
+            'append': _build_readonly_instructions(repos),
+        },
+        hooks={
+            'PreToolUse': [HookMatcher(
+                hooks=[_make_path_guard(workspace_root, READONLY_AGENT_TOOLS)])],
+        },
+    )
+
+
+async def run_readonly_agent(prompt: str, workspace_root: Path,
+                              repos: dict[str, AgentRepo],
+                              on_progress: OnProgress,
+                              resume: str | None = None,
+                              image_paths: list[Path] = ()) -> AgentRunResult:
+    """Read-only variant of run_agent: no Edit/Write tools, no PR plumbing."""
+    result = AgentRunResult(final_text='', timed_out=False)
+    outbox: asyncio.Queue[str | None] = asyncio.Queue()
+
+    async def consume(client: ClaudeSDKClient):
+        async for message in client.receive_response():
+            if isinstance(message, SystemMessage):
+                if message.subtype == 'init':
+                    result.session_id = message.data.get('session_id')
+            elif isinstance(message, AssistantMessage):
+                texts = [block.text for block in message.content
+                         if isinstance(block, TextBlock) and block.text.strip()]
+                if any(isinstance(block, ToolUseBlock)
+                       for block in message.content):
+                    for text in texts:
+                        outbox.put_nowait(text)
+                elif texts:
+                    result.final_text = '\n\n'.join(texts)
+            elif isinstance(message, ResultMessage):
+                if message.result:
+                    result.final_text = message.result
+
+    async def deliver():
+        while (text := await outbox.get()) is not None:
+            await on_progress(text)
+
+    if image_paths:
+        paths_str = '\n'.join(f'- {p}' for p in image_paths)
+        prompt = (f'{prompt}\n\nImage attachment(s) saved in the workspace:\n'
+                  f'{paths_str}\nUse the Read tool to view them.')
+
+    options = _build_readonly_options(workspace_root, repos, resume)
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(prompt)
+        sender = asyncio.create_task(deliver())
+        try:
+            await asyncio.wait_for(consume(client), timeout=AGENT_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            result.timed_out = True
+            try:
+                await client.interrupt()
+            except Exception:
+                pass
+        finally:
+            outbox.put_nowait(None)
+            await sender
+
+    return result
 
 
 async def run_agent(prompt: str, workspace_root: Path,

--- a/jerma/cogs/utils/agent_service.py
+++ b/jerma/cogs/utils/agent_service.py
@@ -25,9 +25,10 @@ from .agent_config import (
     AGENT_REPOS,
     get_conversations_root,
     get_github_token,
+    get_readonly_conversations_root,
     get_workspace_root,
 )
-from .agent_runner import OnProgress, run_agent
+from .agent_runner import OnProgress, run_agent, run_readonly_agent
 from .agent_workspace import (
     AgentWorkspace,
     ConversationCheckout,
@@ -36,6 +37,105 @@ from .agent_workspace import (
 )
 
 STATE_FILE = 'state.json'
+
+_READONLY_EVICTION_IDLE_HOURS = 4
+
+
+@dataclass
+class ReadonlyConversation:
+    """State for one whid-member conversation: just a session ID for resuming."""
+    session_id: str | None = None
+    last_active: datetime = field(default_factory=datetime.now)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class ReadonlyAgentTaskService:
+    """Read-only agent sessions for whid members.
+
+    Shares the same workspace root as AgentTaskService (the pristine clones),
+    but never commits, pushes, or opens pull requests. Conversations are
+    kept in memory only; they survive bot restarts only as long as the Claude
+    SDK keeps the session transcript on disk and we still have the session ID.
+    """
+
+    def __init__(self):
+        self._workspace_root = get_workspace_root()
+        self._repos = AGENT_REPOS
+        self._github_token = get_github_token()
+        self.conversations: dict[int, ReadonlyConversation] = {}
+        self._ensure_task: asyncio.Task | None = None
+
+    def has_conversation(self, key: int) -> bool:
+        return key in self.conversations
+
+    def start(self):
+        self._ensure_task = asyncio.create_task(self._startup())
+
+    def close(self):
+        if self._ensure_task is not None:
+            self._ensure_task.cancel()
+
+    async def run(self, key: int, prompt: str,
+                  on_progress: OnProgress,
+                  images: list[tuple[str, bytes]] = ()) -> TaskReport:
+        """Run one turn of the keyed readonly conversation."""
+        await self._ready()
+        conversation = self._get_or_create(key)
+        async with conversation.lock:
+            conversation.last_active = datetime.now()
+            image_paths = self._save_images(key, images)
+            result = await run_readonly_agent(
+                prompt=prompt,
+                workspace_root=self._workspace_root,
+                repos=self._repos,
+                on_progress=on_progress,
+                resume=conversation.session_id,
+                image_paths=image_paths,
+            )
+            if result.session_id is not None:
+                conversation.session_id = result.session_id
+            return TaskReport(answer=result.final_text,
+                              pull_requests=[],
+                              timed_out=result.timed_out)
+
+    def _get_or_create(self, key: int) -> ReadonlyConversation:
+        if key not in self.conversations:
+            self.conversations[key] = ReadonlyConversation()
+        return self.conversations[key]
+
+    def _save_images(self, key: int,
+                     images: list[tuple[str, bytes]]) -> list[Path]:
+        if not images:
+            return []
+        attachments_dir = self._workspace_root / '_attachments' / str(key)
+        attachments_dir.mkdir(parents=True, exist_ok=True)
+        paths = []
+        for filename, data in images:
+            path = attachments_dir / Path(filename).name
+            path.write_bytes(data)
+            paths.append(path)
+        return paths
+
+    async def _startup(self):
+        # Ensure the pristine clones exist (shared with owner AgentTaskService;
+        # ensure_repos is idempotent and safe to call from both).
+        from .agent_workspace import AgentWorkspace
+        workspace = AgentWorkspace(
+            root=self._workspace_root,
+            repos=self._repos,
+            github_token=self._github_token,
+        )
+        cloned = await workspace.ensure_repos()
+        if cloned:
+            print(f'Readonly agent service: cloned {", ".join(cloned)}')
+
+    async def _ready(self):
+        task = self._ensure_task
+        if task is None or task.cancelled() or (
+                task.done() and task.exception() is not None):
+            task = asyncio.create_task(self._startup())
+            self._ensure_task = task
+        await task
 
 
 @dataclass


### PR DESCRIPTION
---

Add read-only whid-member agent mode with intent classifier

Extends the JermaBot coding agent so whid Discord server members can ping the bot for conversational/code-question responses, without any mutation side effects.

## What changed

**`agent_config.py`**
- Added `WHID_GUILD_ID = 173840048343482368`
- Added `get_readonly_conversations_root()` (env `JERMABOT_AGENT_READONLY_DIR`, default `~/jermabot-agent/readonly-conversations`)

**`agent_runner.py`**
- `_make_path_guard` now accepts an `allowed_tools` parameter (default `AGENT_TOOLS`) so the readonly guard enforces `READONLY_AGENT_TOOLS = ['Read', 'Glob', 'Grep']` at the hook layer as well as at the options layer
- `classify_intent(message_text)` — single-turn, no-tool Claude session that returns `True` only if the message is a genuine conversational request (not a garbled command); silently returns `False` on any error
- `_build_readonly_instructions` / `_build_readonly_options` / `run_readonly_agent` — readonly analogue of the owner pipeline: same streaming/timeout mechanics, no Edit/Write/NotebookEdit tools, no `_split_reply`, returns `AgentRunResult` with empty title/body

**`agent_service.py`**
- `ReadonlyConversation` — lightweight in-memory dataclass (session ID + last-active + lock); no disk persistence since no git state accumulates
- `ReadonlyAgentTaskService` — same `start`/`close`/`has_conversation`/`run` interface as `AgentTaskService`; shares the pristine clone workspace root as `cwd` (so relative paths resolve naturally), saves image attachments under `workspace_root/_attachments/<key>/`, never calls `publish_turn`

**`agent.py`**
- `Agent.__init__` / `cog_load` / `cog_unload` wire up `readonly_service` alongside `service`
- `on_message` splits into two fully separate branches: owner path (unchanged) and whid-member path (new); both share the `_strip_mention` / `_is_own_thread` helpers
- `_is_whid_member` — guild-ID check
- `_handle_readonly_prompt` — same Discord mechanics as `_handle_prompt` (typing indicator, lazy thread creation, chunked sends), minus the PR-link reporting block

## Behaviour

| Trigger | Who | Intent check | Edits/PRs |
|---|---|---|---|
| Ping anywhere | Owner | No | Yes |
| Thread reply (bot-owned) | Owner | No | Yes |
| Ping in whid | Whid member | **Yes** — silent if NO | No |
| Thread reply (bot-owned, established) | Whid member | No (already in session) | No |
| Ping outside whid | Non-owner | — | — (ignored) |

---
Opened by the JermaBot coding agent at the owner's request via Discord.